### PR TITLE
Implement on-demand access token invalidation

### DIFF
--- a/nanoka-idx/Nanoka/Controllers/UserController.cs
+++ b/nanoka-idx/Nanoka/Controllers/UserController.cs
@@ -37,7 +37,8 @@ namespace Nanoka.Controllers
             if (user == null)
                 return Result.StatusCode(HttpStatusCode.Unauthorized, $"Invalid login for user {request.Username}.");
 
-            var expiry  = DateTime.UtcNow.AddMinutes(30);
+            // access token can live extremely long since we have a blacklist
+            var expiry  = DateTime.UtcNow.AddMonths(1);
             var handler = new JwtSecurityTokenHandler();
 
             return new AuthenticationResponse

--- a/nanoka-idx/Nanoka/Controllers/UserController.cs
+++ b/nanoka-idx/Nanoka/Controllers/UserController.cs
@@ -31,12 +31,12 @@ namespace Nanoka.Controllers
             if (user == null)
                 return Result.StatusCode(HttpStatusCode.Unauthorized, $"Invalid login for user {request.Username}.");
 
-            // access token can live extremely long since we have a blacklist
+            // access token can live extremely long since we have an on-demand invalidation mechanism
             var expiry = DateTime.UtcNow.AddMonths(1);
 
             return new AuthenticationResponse
             {
-                AccessToken = _tokenManager.GenerateAccessToken(user, expiry),
+                AccessToken = await _tokenManager.GenerateTokenAsync(user, expiry),
                 User        = user,
                 Expiry      = expiry
             };

--- a/nanoka-idx/Nanoka/Controllers/UserController.cs
+++ b/nanoka-idx/Nanoka/Controllers/UserController.cs
@@ -1,14 +1,8 @@
 using System;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using System.Net;
-using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Nanoka.Models;
 using Nanoka.Models.Requests;
 
@@ -19,13 +13,13 @@ namespace Nanoka.Controllers
     [Authorize]
     public class UserController : ControllerBase
     {
-        readonly NanokaOptions _options;
         readonly UserManager _userManager;
+        readonly TokenManager _tokenManager;
 
-        public UserController(IOptions<NanokaOptions> options, UserManager userManager)
+        public UserController(UserManager userManager, TokenManager tokenManager)
         {
-            _options     = options.Value;
-            _userManager = userManager;
+            _userManager  = userManager;
+            _tokenManager = tokenManager;
         }
 
         [HttpPost("auth")]
@@ -38,28 +32,13 @@ namespace Nanoka.Controllers
                 return Result.StatusCode(HttpStatusCode.Unauthorized, $"Invalid login for user {request.Username}.");
 
             // access token can live extremely long since we have a blacklist
-            var expiry  = DateTime.UtcNow.AddMonths(1);
-            var handler = new JwtSecurityTokenHandler();
+            var expiry = DateTime.UtcNow.AddMonths(1);
 
             return new AuthenticationResponse
             {
-                AccessToken = handler.WriteToken(handler.CreateToken(new SecurityTokenDescriptor
-                {
-                    Subject = new ClaimsIdentity(new[]
-                    {
-                        new Claim(ClaimTypes.NameIdentifier, user.Id),
-                        new Claim(ClaimTypes.Role, ((int) user.Permissions).ToString()),
-                        new Claim("rep", user.Reputation.ToString("F")),
-                        new Claim("rest", user.Restrictions != null && user.Restrictions.Any(r => DateTime.UtcNow < r.End) ? "1" : "0")
-                    }),
-                    Expires = expiry,
-                    SigningCredentials = new SigningCredentials(
-                        new SymmetricSecurityKey(Encoding.Default.GetBytes(_options.Secret)),
-                        SecurityAlgorithms.HmacSha256Signature)
-                })),
-
-                User   = user,
-                Expiry = expiry
+                AccessToken = _tokenManager.GenerateAccessToken(user, expiry),
+                User        = user,
+                Expiry      = expiry
             };
         }
 

--- a/nanoka-idx/Nanoka/DummyUserClaimsProvider.cs
+++ b/nanoka-idx/Nanoka/DummyUserClaimsProvider.cs
@@ -8,6 +8,7 @@ namespace Nanoka
     {
         public string Id { get; set; }
         public UserPermissions Permissions { get; set; }
+        public int Version { get; set; }
         public double Reputation { get; set; }
         public bool IsRestricted { get; set; }
 

--- a/nanoka-idx/Nanoka/HttpUserClaimsProvider.cs
+++ b/nanoka-idx/Nanoka/HttpUserClaimsProvider.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Nanoka.Models;
 
@@ -9,6 +8,7 @@ namespace Nanoka
     {
         public string Id { get; }
         public UserPermissions Permissions { get; }
+        public int Version { get; }
         public double Reputation { get; }
         public bool IsRestricted { get; }
 
@@ -18,10 +18,11 @@ namespace Nanoka
         {
             var context = httpContextAccessor.HttpContext;
 
-            Id           = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            Permissions  = int.TryParse(context.User.FindFirst(ClaimTypes.Role)?.Value, out var b) ? (UserPermissions) b : UserPermissions.None;
-            Reputation   = double.TryParse(context.User.FindFirst("rep")?.Value, out var c) ? c : 0;
-            IsRestricted = bool.TryParse(context.User.FindFirst("rest")?.Value, out var d) && d;
+            Id           = context.User.FindFirst("sub")?.Value;
+            Permissions  = int.TryParse(context.User.FindFirst("role")?.Value, out var b) ? (UserPermissions) b : UserPermissions.None;
+            Version      = int.TryParse(context.User.FindFirst("ver")?.Value, out var c) ? c : 0;
+            Reputation   = double.TryParse(context.User.FindFirst("rep")?.Value, out var d) ? d : 0;
+            IsRestricted = bool.TryParse(context.User.FindFirst("rest")?.Value, out var e) && e;
 
             var query = new Dictionary<string, string>();
 

--- a/nanoka-idx/Nanoka/HttpUserClaimsProvider.cs
+++ b/nanoka-idx/Nanoka/HttpUserClaimsProvider.cs
@@ -20,7 +20,7 @@ namespace Nanoka
 
             Id           = context.User.FindFirst("sub")?.Value;
             Permissions  = int.TryParse(context.User.FindFirst("role")?.Value, out var b) ? (UserPermissions) b : UserPermissions.None;
-            Version      = int.TryParse(context.User.FindFirst("ver")?.Value, out var c) ? c : 0;
+            Version      = int.TryParse(context.User.FindFirst("jti")?.Value, out var c) ? c : 0;
             Reputation   = double.TryParse(context.User.FindFirst("rep")?.Value, out var d) ? d : 0;
             IsRestricted = bool.TryParse(context.User.FindFirst("rest")?.Value, out var e) && e;
 

--- a/nanoka-idx/Nanoka/IUserClaims.cs
+++ b/nanoka-idx/Nanoka/IUserClaims.cs
@@ -7,6 +7,7 @@ namespace Nanoka
     {
         string Id { get; }
         UserPermissions Permissions { get; }
+        int Version { get; }
         double Reputation { get; }
         bool IsRestricted { get; }
 

--- a/nanoka-idx/Nanoka/NanokaOptions.cs
+++ b/nanoka-idx/Nanoka/NanokaOptions.cs
@@ -27,6 +27,5 @@ namespace Nanoka
         public int MaxImageUploadCount { get; set; } = 250;
         public int UploadTaskLimitPerUser { get; set; } = 3;
         public double UploadTaskExpiryMs { get; set; } = 1000 * 60 * 10; // 10 minutes
-        public bool EnableSoftDelete { get; set; } = true;
     }
 }

--- a/nanoka-idx/Nanoka/Startup.cs
+++ b/nanoka-idx/Nanoka/Startup.cs
@@ -61,11 +61,13 @@ namespace Nanoka
             services.AddSingleton<INanokaDatabase, NanokaElasticDatabase>()
                     .AddScoped<SnapshotManager>()
                     .AddScoped<UserManager>()
+                    .AddScoped<TokenManager>()
                     .AddScoped<BookManager>()
                     .AddScoped<VoteManager>();
 
             // storage
-            services.AddSingleton<IStorage>(s => new StorageWrapper(s, _configuration.GetSection("Storage")));
+            services.AddSingleton<IStorage>(s => new StorageWrapper(s, _configuration.GetSection("Storage")))
+                    .AddDistributedMemoryCache();
 
             // uploader
             services.AddScoped<UploadManager>()
@@ -98,6 +100,7 @@ namespace Nanoka
                               .AllowAnyOrigin());
 
             app.UseAuthentication();
+            app.UseMiddleware<TokenValidatingMiddleware>();
             app.UseMvc();
         }
     }

--- a/nanoka-idx/Nanoka/TokenManager.cs
+++ b/nanoka-idx/Nanoka/TokenManager.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Nanoka.Database;
+using Nanoka.Models;
+
+namespace Nanoka
+{
+    public class TokenManager
+    {
+        readonly NanokaOptions _options;
+        readonly INanokaDatabase _db;
+        readonly UserManager _users;
+        readonly IMemoryCache _cache;
+
+        public TokenManager(IOptions<NanokaOptions> options, INanokaDatabase db, UserManager users, IMemoryCache cache)
+        {
+            _options = options.Value;
+            _db      = db;
+            _users   = users;
+            _cache   = cache;
+        }
+
+        public string GenerateAccessToken(User user, DateTime expiry)
+        {
+            var handler = new JwtSecurityTokenHandler();
+
+            return handler.WriteToken(handler.CreateToken(new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, user.Id),
+                    new Claim(ClaimTypes.Role, ((int) user.Permissions).ToString()),
+                    new Claim("rep", user.Reputation.ToString("F")),
+                    new Claim("rest", user.Restrictions != null && user.Restrictions.Any(r => DateTime.UtcNow < r.End) ? "1" : "0")
+                }),
+                Expires = expiry,
+                SigningCredentials = new SigningCredentials(
+                    new SymmetricSecurityKey(Encoding.Default.GetBytes(_options.Secret)),
+                    SecurityAlgorithms.HmacSha256Signature)
+            }));
+        }
+    }
+}

--- a/nanoka-idx/Nanoka/TokenValidatingMiddleware.cs
+++ b/nanoka-idx/Nanoka/TokenValidatingMiddleware.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Nanoka
+{
+    public class TokenValidatingMiddleware : IMiddleware
+    {
+        readonly TokenManager _tokens;
+
+        public TokenValidatingMiddleware(TokenManager tokens)
+        {
+            _tokens = tokens;
+        }
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            if (!await _tokens.IsValidAsync(context.RequestAborted))
+                throw Result.StatusCode(HttpStatusCode.Unauthorized, "Token was invalidated.").Exception;
+
+            await next(context);
+        }
+    }
+}


### PR DESCRIPTION
Implements on-demand access token invalidation by including a version number in all tokens.

On every request the token version is tested against the latest cached value (without querying the db). Requests are rejected if it fails.

When critical user information changes (username, permissions, restrictions, etc.) the latest version is incremented, invalidating every token previously generated.

Resolves #3 