### PR TITLE
Add endpoint for OpenAPI documentation

### DIFF
--- a/nanoka-idx/Nanoka/Controllers/ErrorController.cs
+++ b/nanoka-idx/Nanoka/Controllers/ErrorController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Nanoka.Controllers
 {
     [ApiController]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public class ErrorController : ControllerBase
     {
         [Route("error")]

--- a/nanoka-idx/Nanoka/Nanoka.csproj
+++ b/nanoka-idx/Nanoka/Nanoka.csproj
@@ -5,6 +5,11 @@
         <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="9.0.0"/>
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection">
@@ -19,6 +24,12 @@
         </PackageReference>
         <PackageReference Include="SixLabors.ImageSharp">
             <Version>1.0.0-beta0007</Version>
+        </PackageReference>
+        <PackageReference Include="Swashbuckle.AspNetCore.Swagger">
+            <Version>4.0.1</Version>
+        </PackageReference>
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen">
+            <Version>4.0.1</Version>
         </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
OpenAPI documentation automatically generated using Swashbuckle at `/docs/v1.json`.